### PR TITLE
feat: 유저 마이페이지 조회 기능 응답에 joinedDate 값 추가

### DIFF
--- a/src/main/kotlin/kr/co/lokit/api/domain/user/application/MyPageService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/application/MyPageService.kt
@@ -75,6 +75,7 @@ class MyPageService(
             couplePhotoCount = couplePhotoCount,
             defaultAlbumId = defaultAlbumId,
             backgroundImageUrl = backgroundImageUrl,
+            joinedDate = me.joinedAt?.toLocalDate(),
         )
     }
 

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/domain/MyPageReadModel.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/domain/MyPageReadModel.kt
@@ -13,4 +13,5 @@ data class MyPageReadModel(
     val couplePhotoCount: Long,
     val defaultAlbumId: Long,
     val backgroundImageUrl: String?,
+    val joinedDate: LocalDate?,
 )

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/domain/User.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/domain/User.kt
@@ -12,6 +12,7 @@ data class User(
     var profileImageUrl: String? = null,
     val status: AccountStatus = AccountStatus.ACTIVE,
     val withdrawnAt: LocalDateTime? = null,
+    val joinedAt: LocalDateTime? = null
 ) {
     fun withNickname(nickname: String): User = copy(name = nickname)
 

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/dto/MyPageDto.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/dto/MyPageDto.kt
@@ -46,4 +46,6 @@ data class MyPageResponse(
     val defaultAlbumId: Long,
     @Schema(description = "랜덤 배경 사진", example = "https://example.com/background.jpg")
     val backgroundImageUrl: String?,
+    @Schema(description = "회원가입 날짜", example = "2026-04-01")
+    val joinedDate: LocalDate?,
 )

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/infrastructure/mapping/UserEntityMappings.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/infrastructure/mapping/UserEntityMappings.kt
@@ -12,6 +12,7 @@ fun UserEntity.toDomain(): User =
         profileImageUrl = profileImageUrl,
         status = status,
         withdrawnAt = withdrawnAt,
+        joinedAt = createdAt,
     )
 
 fun User.toEntity(): UserEntity =

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/mapping/MyPageDtoMappings.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/mapping/MyPageDtoMappings.kt
@@ -15,4 +15,5 @@ fun MyPageReadModel.toResponse(): MyPageResponse =
         couplePhotoCount = couplePhotoCount,
         defaultAlbumId = defaultAlbumId,
         backgroundImageUrl = backgroundImageUrl,
+        joinedDate = joinedDate,
     )


### PR DESCRIPTION
## 수정 이유
- #3 

## 추가/수정한 기능
- 마이페이지 조회 기능에 joinedDate (회원가입 날짜) 추가

## 특이사항
- createdAt을 활용했으며 User 도메인 클래스에는 원본 데이터가 있는 것이 맞다고 판단하여 LocalDateTime 타입의 joinedAt을 추가하였고 응답값에는 요구사항에 맞게 LocalDate 타입으로 joinedDate 을 추가하였습니다.

## check list

- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
