### PR TITLE
chore: map/me 조회 시 주소 정보 제거

### DIFF
--- a/src/main/kotlin/kr/co/lokit/api/domain/map/application/MapQueryService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/map/application/MapQueryService.kt
@@ -184,7 +184,7 @@ class MapQueryService(
         val (locationFuture, albumsFuture, photosFuture) =
             StructuredConcurrency.run { scope ->
                 Triple(
-                    scope.fork { mapClientPort.reverseGeocode(longitude, latitude) },
+                    scope.fork { mapClientPort.reverseGeocode(longitude, latitude) }, // TODO: 제거
                     scope.fork {
                         dbSemaphore.withPermit {
                             findAlbumsForCouple(context.coupleId)
@@ -204,12 +204,12 @@ class MapQueryService(
                 )
             }
 
-        val formattedLocation = formatLocation(locationFuture.get())
+        val formattedLocation = formatLocation(locationFuture.get()) // TODO: 제거
         val photosResponse = photosFuture.get()
         val albums = albumsFuture.get()
 
         return MapMeReadModel(
-            location = formattedLocation,
+            location = formattedLocation, // TODO: 제거
             boundingBox = bbox.toBoundingBoxReadModel(),
             albums = albums.toAlbumThumbnailsReadModels(),
             dataVersion = currentVersion,

--- a/src/main/kotlin/kr/co/lokit/api/domain/map/domain/MapReadModels.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/map/domain/MapReadModels.kt
@@ -163,7 +163,7 @@ value class AlbumThumbnails private constructor(
 }
 
 data class MapMeReadModel(
-    val location: LocationInfoReadModel,
+    val location: LocationInfoReadModel, // TODO: 제거
     val boundingBox: BoundingBoxReadModel,
     val totalHistoryCount: Int,
     val albums: AlbumThumbnails,

--- a/src/main/kotlin/kr/co/lokit/api/domain/map/dto/MapDto.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/map/dto/MapDto.kt
@@ -253,9 +253,27 @@ data class HomeResponse(
 }
 
 @Schema(description = "지도 ME 응답 (홈 + 사진 조회 통합)")
-data class MapMeResponse(
+data class LegacyMapMeResponse(
     @Schema(description = "위치 정보")
     val location: LocationInfoResponse,
+    @Schema(description = "바운딩 박스")
+    val boundingBox: BoundingBoxResponse,
+    @Schema(description = "기록 수(전체 보기 사진 개수)")
+    val totalHistoryCount: Int,
+    @Schema(description = "앨범 하이라이트 사진들 (최대 4장)")
+    val albums: List<HomeResponse.Companion.AlbumThumbnails>,
+    @Schema(description = "데이터 버전 (사진 변경 시 증가, 프론트 캐싱에 사용)")
+    val dataVersion: Long = 0,
+    @Schema(description = "클러스터 목록 (줌 < 15일 때)")
+    val clusters: List<ClusterResponse>? = null,
+    @Schema(description = "개별 사진 목록 (줌 >= 15일 때)")
+    val photos: List<MapPhotoResponse>? = null,
+    @Schema(description = "내 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    val profileImageUrl: String?,
+)
+
+@Schema(description = "지도 ME 응답 (홈 + 사진 조회 통합)")
+data class MapMeResponse(
     @Schema(description = "바운딩 박스")
     val boundingBox: BoundingBoxResponse,
     @Schema(description = "기록 수(전체 보기 사진 개수)")

--- a/src/main/kotlin/kr/co/lokit/api/domain/map/presentation/MapApi.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/map/presentation/MapApi.kt
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import kr.co.lokit.api.domain.map.dto.AlbumMapInfoResponse
 import kr.co.lokit.api.domain.map.dto.ClusterPhotoResponse
+import kr.co.lokit.api.domain.map.dto.LegacyMapMeResponse
 import kr.co.lokit.api.domain.map.dto.LocationInfoResponse
 import kr.co.lokit.api.domain.map.dto.MapMeResponse
 import kr.co.lokit.api.domain.map.dto.PlaceSearchResponse
@@ -37,7 +38,71 @@ interface MapApi {
             ApiResponse(
                 responseCode = "200",
                 description = "조회 성공",
-                content = [Content(schema = Schema(implementation = MapMeResponse::class))],
+                content = [Content(schema = Schema(implementation = LegacyMapMeResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 파라미터",
+                content = [Content()],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증 필요",
+                content = [Content()],
+            ),
+        ],
+    )
+    fun legacyGetMe(
+        @Parameter(hidden = true) user: User,
+        @Parameter(
+            description = "경도",
+            example = "127.0276",
+            required = true,
+        )
+        @RequestParam longitude: Double,
+        @Parameter(
+            description = "위도",
+            example = "37.4979",
+            required = true,
+        )
+        @RequestParam latitude: Double,
+        @Parameter(
+            description = "줌 레벨(소수점 지원). 15 미만이면 클러스터링, 15 이상이면 개별 사진 반환",
+            example = "12.5",
+            required = true,
+        )
+        @RequestParam zoom: Double,
+        @Parameter(
+            description = "앨범 ID (선택). 지정 시 해당 앨범의 사진만 조회",
+            example = "1",
+            required = false,
+        )
+        @RequestParam albumId: Long?,
+        @Parameter(
+            description = "이전 응답의 dataVersion. 클라이언트 캐시 동기화 판단에 사용",
+            example = "3",
+            required = false,
+        )
+        @RequestParam lastDataVersion: Long?,
+    ): LegacyMapMeResponse
+
+    @Operation(
+        operationId = "getMapMe",
+        summary = "지도 ME 조회 (홈 + 사진 조회 통합)",
+        description = """
+            홈 정보와 지도 사진을 한 번에 조회합니다.
+
+            - 위치 정보, 앨범 목록, 바운딩 박스 (map/home 응답)
+            - 줌 레벨과 바운딩 박스 기반 사진/클러스터 (map/photos 응답)
+            - 두 API를 하나로 통합하여 네트워크 요청을 줄입니다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content = [Content(schema = Schema(implementation = LegacyMapMeResponse::class))],
             ),
             ApiResponse(
                 responseCode = "400",

--- a/src/main/kotlin/kr/co/lokit/api/domain/map/presentation/MapController.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/map/presentation/MapController.kt
@@ -6,9 +6,11 @@ import kr.co.lokit.api.domain.map.application.port.`in`.GetMapUseCase
 import kr.co.lokit.api.domain.map.application.port.`in`.SearchLocationUseCase
 import kr.co.lokit.api.domain.map.dto.AlbumMapInfoResponse
 import kr.co.lokit.api.domain.map.dto.ClusterPhotoResponse
+import kr.co.lokit.api.domain.map.dto.LegacyMapMeResponse
 import kr.co.lokit.api.domain.map.dto.LocationInfoResponse
 import kr.co.lokit.api.domain.map.dto.MapMeResponse
 import kr.co.lokit.api.domain.map.dto.PlaceSearchResponse
+import kr.co.lokit.api.domain.map.presentation.mapping.toLegacyResponse
 import kr.co.lokit.api.domain.map.presentation.mapping.toResponse
 import kr.co.lokit.api.domain.user.domain.User
 import org.springframework.security.access.prepost.PreAuthorize
@@ -24,7 +26,27 @@ class MapController(
     private val getMapUseCase: GetMapUseCase,
     private val searchLocationUseCase: SearchLocationUseCase,
 ) : MapApi {
+    @Deprecated("Legacy API (제거 필요)")
     @GetMapping("me")
+    override fun legacyGetMe(
+        @CurrentUser user: User,
+        @RequestParam longitude: Double,
+        @RequestParam latitude: Double,
+        @RequestParam zoom: Double,
+        @RequestParam(required = false) albumId: Long?,
+        @RequestParam(required = false) lastDataVersion: Long?,
+    ): LegacyMapMeResponse =
+        getMapUseCase
+            .getMe(
+                user,
+                longitude,
+                latitude,
+                zoom,
+                albumId,
+                lastDataVersion,
+            ).toLegacyResponse()
+
+    @GetMapping("me", version = "1.1")
     override fun getMe(
         @CurrentUser user: User,
         @RequestParam longitude: Double,

--- a/src/main/kotlin/kr/co/lokit/api/domain/map/presentation/mapping/MapDtoMappings.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/map/presentation/mapping/MapDtoMappings.kt
@@ -16,15 +16,27 @@ import kr.co.lokit.api.domain.map.dto.BoundingBoxResponse
 import kr.co.lokit.api.domain.map.dto.ClusterPhotoResponse
 import kr.co.lokit.api.domain.map.dto.ClusterResponse
 import kr.co.lokit.api.domain.map.dto.HomeResponse
+import kr.co.lokit.api.domain.map.dto.LegacyMapMeResponse
 import kr.co.lokit.api.domain.map.dto.LocationInfoResponse
 import kr.co.lokit.api.domain.map.dto.MapMeResponse
 import kr.co.lokit.api.domain.map.dto.MapPhotoResponse
 import kr.co.lokit.api.domain.map.dto.PlaceResponse
 import kr.co.lokit.api.domain.map.dto.PlaceSearchResponse
 
+fun MapMeReadModel.toLegacyResponse(): LegacyMapMeResponse =
+    LegacyMapMeResponse(
+        location = location.toResponse(),
+        boundingBox = boundingBox.toResponse(),
+        totalHistoryCount = totalHistoryCount,
+        albums = albums.asList().map { it.toResponse() },
+        dataVersion = dataVersion,
+        clusters = clusters?.asList()?.map { it.toResponse() },
+        photos = photos?.asList()?.map { it.toResponse() },
+        profileImageUrl = profileImageUrl,
+    )
+
 fun MapMeReadModel.toResponse(): MapMeResponse =
     MapMeResponse(
-        location = location.toResponse(),
         boundingBox = boundingBox.toResponse(),
         totalHistoryCount = totalHistoryCount,
         albums = albums.asList().map { it.toResponse() },


### PR DESCRIPTION
## 수정 이유
- #10 
- 홈 (map/me) 에서 주소 정보가 필요 없어짐

## 추가/수정한 기능
- map/me 주소 정보 제거 api 를 version 1.1 로 추가

## 특이사항
- [springboot 4.0 버저닝](https://docs.spring.io/spring-framework/reference/web/webmvc-versioning.html) 을 헤더로 활용했습니다.

## check list

- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
