### PR TITLE
feat: login redirect 응답 추가(isNewUser,userId) / /map/me 응답값 추가 (userId)

### DIFF
--- a/src/main/kotlin/kr/co/lokit/api/domain/map/application/MapQueryService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/map/application/MapQueryService.kt
@@ -13,23 +13,7 @@ import kr.co.lokit.api.domain.map.application.port.MapClientPort
 import kr.co.lokit.api.domain.map.application.port.MapQueryPort
 import kr.co.lokit.api.domain.map.application.port.`in`.GetMapUseCase
 import kr.co.lokit.api.domain.map.application.port.`in`.SearchLocationUseCase
-import kr.co.lokit.api.domain.map.domain.AlbumMapInfoReadModel
-import kr.co.lokit.api.domain.map.domain.AlbumThumbnails
-import kr.co.lokit.api.domain.map.domain.AlbumThumbnailsReadModel
-import kr.co.lokit.api.domain.map.domain.BBox
-import kr.co.lokit.api.domain.map.domain.BoundsIdType
-import kr.co.lokit.api.domain.map.domain.ClusterId
-import kr.co.lokit.api.domain.map.domain.ClusterPhotos
-import kr.co.lokit.api.domain.map.domain.Clusters
-import kr.co.lokit.api.domain.map.domain.GridValues
-import kr.co.lokit.api.domain.map.domain.LocationInfoReadModel
-import kr.co.lokit.api.domain.map.domain.MapMeReadModel
-import kr.co.lokit.api.domain.map.domain.MapPhotos
-import kr.co.lokit.api.domain.map.domain.MapPhotosReadModel
-import kr.co.lokit.api.domain.map.domain.MapZoom
-import kr.co.lokit.api.domain.map.domain.MercatorProjection
-import kr.co.lokit.api.domain.map.domain.PlaceSearchReadModel
-import kr.co.lokit.api.domain.map.domain.ThumbnailUrls
+import kr.co.lokit.api.domain.map.domain.*
 import kr.co.lokit.api.domain.user.domain.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -217,6 +201,7 @@ class MapQueryService(
             photos = photosResponse.photos,
             totalHistoryCount = albumRepository.photoCountSumByUserId(user.id),
             profileImageUrl = user.profileImageUrl,
+            userId = user.id,
         )
     }
 

--- a/src/main/kotlin/kr/co/lokit/api/domain/map/domain/MapReadModels.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/map/domain/MapReadModels.kt
@@ -171,4 +171,5 @@ data class MapMeReadModel(
     val clusters: Clusters?,
     val photos: MapPhotos?,
     val profileImageUrl: String?,
+    val userId: Long
 )

--- a/src/main/kotlin/kr/co/lokit/api/domain/map/dto/MapDto.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/map/dto/MapDto.kt
@@ -288,4 +288,6 @@ data class MapMeResponse(
     val photos: List<MapPhotoResponse>? = null,
     @Schema(description = "내 프로필 이미지 URL", example = "https://example.com/profile.jpg")
     val profileImageUrl: String?,
+    @Schema(description = "내 회원 ID", example = "1")
+    val userId: Long,
 )

--- a/src/main/kotlin/kr/co/lokit/api/domain/map/presentation/mapping/MapDtoMappings.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/map/presentation/mapping/MapDtoMappings.kt
@@ -1,27 +1,7 @@
 package kr.co.lokit.api.domain.map.presentation.mapping
 
-import kr.co.lokit.api.domain.map.domain.AlbumMapInfoReadModel
-import kr.co.lokit.api.domain.map.domain.AlbumThumbnailsReadModel
-import kr.co.lokit.api.domain.map.domain.BoundingBoxReadModel
-import kr.co.lokit.api.domain.map.domain.ClusterPhotoReadModel
-import kr.co.lokit.api.domain.map.domain.ClusterPhotos
-import kr.co.lokit.api.domain.map.domain.ClusterReadModel
-import kr.co.lokit.api.domain.map.domain.LocationInfoReadModel
-import kr.co.lokit.api.domain.map.domain.MapMeReadModel
-import kr.co.lokit.api.domain.map.domain.MapPhotoReadModel
-import kr.co.lokit.api.domain.map.domain.PlaceReadModel
-import kr.co.lokit.api.domain.map.domain.PlaceSearchReadModel
-import kr.co.lokit.api.domain.map.dto.AlbumMapInfoResponse
-import kr.co.lokit.api.domain.map.dto.BoundingBoxResponse
-import kr.co.lokit.api.domain.map.dto.ClusterPhotoResponse
-import kr.co.lokit.api.domain.map.dto.ClusterResponse
-import kr.co.lokit.api.domain.map.dto.HomeResponse
-import kr.co.lokit.api.domain.map.dto.LegacyMapMeResponse
-import kr.co.lokit.api.domain.map.dto.LocationInfoResponse
-import kr.co.lokit.api.domain.map.dto.MapMeResponse
-import kr.co.lokit.api.domain.map.dto.MapPhotoResponse
-import kr.co.lokit.api.domain.map.dto.PlaceResponse
-import kr.co.lokit.api.domain.map.dto.PlaceSearchResponse
+import kr.co.lokit.api.domain.map.domain.*
+import kr.co.lokit.api.domain.map.dto.*
 
 fun MapMeReadModel.toLegacyResponse(): LegacyMapMeResponse =
     LegacyMapMeResponse(
@@ -44,6 +24,7 @@ fun MapMeReadModel.toResponse(): MapMeResponse =
         clusters = clusters?.asList()?.map { it.toResponse() },
         photos = photos?.asList()?.map { it.toResponse() },
         profileImageUrl = profileImageUrl,
+        userId = userId,
     )
 
 fun ClusterPhotos.toResponse(): List<ClusterPhotoResponse> = asList().map { it.toResponse() }

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/application/AppleLoginService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/application/AppleLoginService.kt
@@ -47,15 +47,18 @@ class AppleLoginService(
 
         val loginResult =
             lockManager.withLock(key = User.emailLockKey(email), operation = {
-                val loadedUser = userRepository.findByEmail(email)
+                val (loadedUser, isNew) = userRepository.findByEmail(email)
+                    ?.let { it to false }
+                    ?: (userRepository.save(User(email = email, name = User.defaultNicknameFor(email))) to true)
                 val recovered = reactivateIfNeeded(loadedUser)
                 createCoupleUseCase.createIfNone(Couple(name = Couple.DEFAULT_COUPLE_NAME), loadedUser.id)
-                LoginLoadResult(user = loadedUser.recoveredIf(recovered), recovered = recovered)
+                LoginLoadResult(user = loadedUser.recoveredIf(recovered), recovered = recovered, isNew = isNew)
             })
 
         return LoginResult(
             userId = loginResult.user.id,
             tokens = generateTokens(loginResult.user),
+            isNewUser = loginResult.isNew,
         )
     }
 
@@ -98,5 +101,6 @@ class AppleLoginService(
     private data class LoginLoadResult(
         val user: User,
         val recovered: Boolean,
+        val isNew: Boolean,
     )
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/application/KakaoLoginService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/application/KakaoLoginService.kt
@@ -49,10 +49,12 @@ class KakaoLoginService(
 
         val loginResult =
             lockManager.withLock(key = User.emailLockKey(email), operation = {
-                val loadedUser = userRepository.findByEmail(email)
+                val (loadedUser, isNew) = userRepository.findByEmail(email)
+                    ?.let { it to false }
+                    ?: (userRepository.save(User(email = email, name = User.defaultNicknameFor(email))) to true)
                 val recovered = reactivateIfNeeded(loadedUser)
                 createCoupleUseCase.createIfNone(Couple(name = Couple.DEFAULT_COUPLE_NAME), loadedUser.id)
-                LoginLoadResult(user = loadedUser.recoveredIf(recovered), recovered = recovered)
+                LoginLoadResult(user = loadedUser.recoveredIf(recovered), recovered = recovered, isNew = isNew)
             })
 
         if (loginResult.recovered) {
@@ -63,6 +65,7 @@ class KakaoLoginService(
         return LoginResult(
             userId = loginResult.user.id,
             tokens = generateTokens(loginResult.user),
+            isNewUser = loginResult.isNew,
         )
     }
 
@@ -105,5 +108,6 @@ class KakaoLoginService(
     private data class LoginLoadResult(
         val user: User,
         val recovered: Boolean,
+        val isNew: Boolean,
     )
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/application/port/UserRepositoryPort.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/application/port/UserRepositoryPort.kt
@@ -7,7 +7,7 @@ interface UserRepositoryPort {
 
     fun findById(id: Long): User?
 
-    fun findByEmail(email: String): User
+    fun findByEmail(email: String): User?
 
     fun update(user: User): User
 

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/domain/LoginResult.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/domain/LoginResult.kt
@@ -3,4 +3,5 @@ package kr.co.lokit.api.domain.user.domain
 data class LoginResult(
     val userId: Long,
     val tokens: AuthTokens,
+    val isNewUser: Boolean,
 )

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/infrastructure/JpaUserRepository.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/infrastructure/JpaUserRepository.kt
@@ -23,27 +23,17 @@ class JpaUserRepository(
     override fun findById(id: Long): User? = userJpaRepository.findByIdOrNull(id)?.toDomain()
 
     @Transactional
-    override fun findByEmail(email: String): User {
+    override fun findByEmail(email: String): User? {
         val existing = userJpaRepository.findByEmail(email)
-        if (existing != null) {
-            return existing.toDomain()
-        }
+        if (existing != null) return existing.toDomain()
 
         val restoredCount = userJpaRepository.restoreDeletedByEmail(email)
         if (restoredCount > 0) {
-            val restored =
-                userJpaRepository.findByEmail(email)
-                    ?: throw IllegalStateException("Restored user not found for email: $email")
-            return restored.toDomain()
+            return userJpaRepository.findByEmail(email)?.toDomain()
+                ?: throw IllegalStateException("Restored user not found for email: $email")
         }
 
-        return userJpaRepository
-            .save(
-                User(
-                    email = email,
-                    name = User.defaultNicknameFor(email),
-                ).toEntity(),
-            ).toDomain()
+        return null
     }
 
     @Transactional

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/AuthController.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/AuthController.kt
@@ -122,7 +122,7 @@ class AuthController(
                 .header("Expires", "0")
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-                .location(URI.create(redirectUri))
+                .location(URI.create(buildSuccessRedirectUri(redirectUri, loginResult.userId, loginResult.isNewUser)))
                 .build()
         } catch (ex: BusinessException) {
             log.info("Kakao callback failed: code={}, redirectUri={}", ex.errorCode.code, redirectUri)
@@ -171,7 +171,7 @@ class AuthController(
                 .header("Expires", "0")
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-                .location(URI.create(redirectUri))
+                .location(URI.create(buildSuccessRedirectUri(redirectUri, loginResult.userId, loginResult.isNewUser)))
                 .build()
         } catch (ex: BusinessException) {
             log.info("Apple callback failed: code={}, redirectUri={}", ex.errorCode.code, redirectUri)
@@ -220,6 +220,18 @@ class AuthController(
         } catch (_: Exception) {
             false
         }
+
+    private fun buildSuccessRedirectUri(
+        redirectUri: String,
+        userId: Long,
+        isNewUser: Boolean,
+    ): String =
+        UriComponentsBuilder
+            .fromUriString(redirectUri)
+            .queryParam("user_id", userId)
+            .queryParam("is_new_user", isNewUser)
+            .build(true)
+            .toUriString()
 
     private fun buildErrorRedirectUri(
         redirectUri: String,

--- a/src/test/kotlin/kr/co/lokit/api/domain/map/presentation/MapControllerTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/map/presentation/MapControllerTest.kt
@@ -73,6 +73,7 @@ class MapControllerTest {
             clusters = Clusters.empty(),
             photos = null,
             profileImageUrl = "https://example.com/profile.jpg",
+            userId = 1L,
         )
 
     @Test

--- a/src/test/kotlin/kr/co/lokit/api/domain/user/infrastructure/JpaUserRepositoryTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/user/infrastructure/JpaUserRepositoryTest.kt
@@ -1,14 +1,12 @@
 package kr.co.lokit.api.domain.user.infrastructure
 
 import kr.co.lokit.api.fixture.createUserEntity
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -31,7 +29,7 @@ class JpaUserRepositoryTest {
 
         val found = repository.findByEmail("active@test.com")
 
-        assertEquals(1L, found.id)
+        assertEquals(1L, found!!.id)
         assertEquals("active@test.com", found.email)
     }
 
@@ -43,22 +41,18 @@ class JpaUserRepositoryTest {
 
         val found = repository.findByEmail("restore@test.com")
 
-        assertEquals(2L, found.id)
+        assertEquals(2L, found!!.id)
         verify(userJpaRepository).restoreDeletedByEmail("restore@test.com")
     }
 
     @Test
-    fun `복구 대상이 없으면 신규 유저를 생성한다`() {
-        val created = createUserEntity(id = 3L, email = "new@test.com", name = "new")
+    fun `복구 대상이 없으면 null을 반환한다`() {
         whenever(userJpaRepository.findByEmail("new@test.com")).thenReturn(null)
         whenever(userJpaRepository.restoreDeletedByEmail("new@test.com")).thenReturn(0)
-        whenever(userJpaRepository.save(any<UserEntity>())).thenReturn(created)
 
         val found = repository.findByEmail("new@test.com")
 
-        assertEquals(3L, found.id)
-        assertEquals("new@test.com", found.email)
-        verify(userJpaRepository).save(any<UserEntity>())
+        assertNull(found)
     }
 
     @Test


### PR DESCRIPTION
## 수정 이유

프론트의 요청

## 추가/수정한 기능
- /map/me api에 응답값 추가 -> userId 필드를 응답객체에 포함
- 기존에 findByEmail 호출 시 내부에서 저장 로직까지 포함되어있었는데, 이를 단순 조회용으로 변경하고 회원이 없으면 null을 반환하도록 했습니다.
- 서비스 레이어에서 null인지 회원객체가 있는 지를 판별하여 별도로save 로직을 호출해서 isNewUser 값을 판별합니다.

## 특이사항

## check list

- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [ ] 추가/수정사항을 설명했나요?
